### PR TITLE
Changes to the OpenFlow 1.2 match framework  

### DIFF
--- a/src/python/of12/match.py
+++ b/src/python/of12/match.py
@@ -1,12 +1,15 @@
 
 # Python OpenFlow instruction wrapper classes
 
+import struct
 import ipaddr
+import socket
 from cstruct import *
 
 
-class oxm_tlv:
-    def __init__(self, field, hasmask, length, value, mask=None, class_ = 0x8000):
+class oxm_tlv(object):
+    def __init__(self, field, hasmask, length, value, mask=None, 
+        class_ = 0x8000):
         self.class_ = class_
         self.field = field
         self.hasmask = hasmask
@@ -14,10 +17,17 @@ class oxm_tlv:
         self.value = value
         self.mask = mask
     
+    def __eq__(self, other):        
+        return (self.class_ == other.class_ and self.field == other.field 
+                  and self.hasmask == other.hasmask and 
+                  self.length == other.length and self.value == other.value and
+                  self.mask == self.mask)
+
     def pack(self, assertstruct=True):
         
         packed = ""
-        packed += struct.pack("!I", ((self.class_ << 16) | (self.field << 9) | (self.hasmask << 8) | self.length))
+        packed += struct.pack("!I", ((self.class_ << 16) | (self.field << 9) | 
+            (self.hasmask << 8) | self.length))
         if self.length == 1:
             packed += struct.pack("B", self.value)
             if self.hasmask:
@@ -31,9 +41,11 @@ class oxm_tlv:
             if self.hasmask:
                 packed += struct.pack("!I", self.mask)
         elif self.length == 6 or self.length == 12:
-            packed += struct.pack("!BBBBBB", self.value[0],self.value[1],self.value[2],self.value[3],self.value[4],self.value[5])
+            packed += struct.pack("!BBBBBB", self.value[0],self.value[1],
+                self.value[2],self.value[3],self.value[4],self.value[5])
             if self.hasmask:
-                packed += struct.pack("!BBBBBB", self.mask[0],self.mask[1],self.mask[2],self.mask[3],self.mask[4],self.mask[5])
+                packed += struct.pack("!BBBBBB", self.mask[0],self.mask[1],
+                    self.mask[2],self.mask[3],self.mask[4],self.mask[5])
         elif self.length == 8 or (self.length == 16 and self.hasmask == True):
             packed += struct.pack("!Q", self.value)
             if self.hasmask:
@@ -50,11 +62,33 @@ class oxm_tlv:
     def show(self, prefix=''):
         return "\n".join(
 #        ("oxm_tlv_class=" + hex(self.class_),
-        ("oxm_tlv_class=" + str(self.class_),
-        "oxm_tlv_field=" + hex(self.field),
-        "oxm_tlv_hasmask=" + str(bool(self.hasmask)),
-        "oxm_tlv_length: " + hex(self.length),
-        "value: " + str(self.value),))
+        (prefix + "oxm_tlv_class=" + hex(self.class_),
+         prefix + "oxm_tlv_field=" + str(self.field),
+         prefix +"oxm_tlv_hasmask=" + str(bool(self.hasmask)),
+         prefix +"oxm_tlv_length: " + str(self.length) + "\n",))
+        
+
+    subclasses = {}
+
+    def set_value(self, value):
+        self.value = value
+
+    def set_hasmask(self, hasmask):
+        self.hasmask = hasmask
+
+    def set_mask(self, mask):
+        self.mask = mask
+
+    @staticmethod
+    def factory():
+        for subclass in oxm_tlv.__subclasses__():
+            obj = subclass()
+            oxm_tlv.subclasses[obj.field] = subclass
+   
+    @staticmethod
+    def create(field):
+        return oxm_tlv.subclasses[field]()
+
 
 
 def roundup (x,y): 
@@ -71,11 +105,12 @@ class in_port(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_IN_PORT , hasmask, 4, value)
     def show(self, prefix=''):
-        outstr = prefix + "in_port\n"
-        outstr += oxm_tlv.show(self, prefix)
+        outstr = prefix + "name = in_port\n"
+        outstr += oxm_tlv.show(self, prefix) 
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr
 
 
@@ -90,11 +125,12 @@ class in_phy_port(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self,OFPXMT_OFB_IN_PHY_PORT, hasmask, 4, value)
     def show(self, prefix=''):
-        outstr = prefix + "in_phy_port\n"
+        outstr = prefix + "name = in_phy_port\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr
 
 
@@ -109,14 +145,15 @@ class metadata(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, mask = None):
+    def __init__(self, value=None, mask =None):
         if mask == None:
             oxm_tlv.__init__(self, OFPXMT_OFB_METADATA, False, 8, value)
         else:
             oxm_tlv.__init__(self, OFPXMT_OFB_METADATA, True, 16, value, mask)            
     def show(self, prefix=''):
-        outstr = prefix + "metadata\n"
+        outstr = prefix + "name = metadata\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr
 
 class eth_dst(oxm_tlv):
@@ -130,14 +167,16 @@ class eth_dst(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, mask = None):
+    def __init__(self, value=None, mask=None):
         if mask == None:
             oxm_tlv.__init__(self, OFPXMT_OFB_ETH_DST, False, 6, value)
         else:
             oxm_tlv.__init__(self, OFPXMT_OFB_ETH_DST, True, 12, value, mask)            
     def show(self, prefix=''):
-        outstr = prefix + "eth_dst\n"
+        outstr = prefix + "name = eth_dst\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + ":".join(["%.2x" %x 
+            for x in self.value]) +"\n"
         return outstr
   
 class eth_src(oxm_tlv):
@@ -151,14 +190,17 @@ class eth_src(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         if not hasmask:
             oxm_tlv.__init__(self, OFPXMT_OFB_ETH_SRC, hasmask, 6, value)
         else:
-            oxm_tlv.__init__(self, OFPXMT_OFB_ETH_SRC, hasmask, 12, value, mask)            
+            oxm_tlv.__init__(self, OFPXMT_OFB_ETH_SRC, hasmask, 12, 
+                value, mask)            
     def show(self, prefix=''):
-        outstr = prefix + "eth_src\n"
+        outstr = prefix + "name = eth_src\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + ":".join(["%.2x" %x 
+            for x in self.value]) +"\n"
         return outstr
 
 class eth_type(oxm_tlv):
@@ -172,11 +214,12 @@ class eth_type(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_ETH_TYPE, hasmask, 2, value)
     def show(self, prefix=''):
-        outstr = prefix + "eth_type\n"
+        outstr = prefix + "name = eth_type\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + hex(self.value) +"\n"
         return outstr
 
 class vlan_vid(oxm_tlv):
@@ -190,11 +233,12 @@ class vlan_vid(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_VLAN_VID, hasmask, 2, value)
     def show(self, prefix=''):
-        outstr = prefix + "vlan_vid\n"
+        outstr = prefix + "name = vlan_vid\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr
 
 class vlan_pcp(oxm_tlv):
@@ -208,11 +252,12 @@ class vlan_pcp(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_VLAN_PCP, hasmask, 1, value)
     def show(self, prefix=''):
-        outstr = prefix + "vlan_pcp\n"
+        outstr = prefix + "name = vlan_pcp\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr
         
 class ip_dscp(oxm_tlv):
@@ -226,11 +271,12 @@ class ip_dscp(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_IP_DSCP, hasmask, 1, value)
     def show(self, prefix=''):
-        outstr = prefix + "ip_dscp\n"
+        outstr = prefix + "name = ip_dscp\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr
 
 class ip_ecn(oxm_tlv):
@@ -244,11 +290,12 @@ class ip_ecn(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_IP_ECN, hasmask, 1, value)
     def show(self, prefix=''):
-        outstr = prefix + "ip_ecn\n"
+        outstr = prefix + "name = ip_ecn\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"        
         return outstr
 
 class ip_proto(oxm_tlv):
@@ -262,11 +309,12 @@ class ip_proto(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_IP_PROTO, hasmask, 1, value)
     def show(self, prefix=''):
-        outstr = prefix + "ip_proto\n"
+        outstr = prefix + "name = ip_proto\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr
 
 class ipv4_src(oxm_tlv):
@@ -280,14 +328,20 @@ class ipv4_src(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         if not hasmask:
             oxm_tlv.__init__(self, OFPXMT_OFB_IPV4_SRC, hasmask, 4, value)
         else: 
             oxm_tlv.__init__(self, OFPXMT_OFB_IPV4_SRC, hasmask, 4, value, mask)
     def show(self, prefix=''):
-        outstr = prefix + "ipv4_src\n"
+        outstr = prefix + "name = ipv4_src\n"
         outstr += oxm_tlv.show(self, prefix)
+        #Value can be a long int or a string        
+        try:
+            addr = ipaddr.IPv4Address(self.value)
+        except ValueError:
+            addr = ipaddr.IPv4Address(int(self.value, 16))
+        outstr += prefix + "value = " + str(addr) +"\n"
         return outstr
 
 class ipv4_dst(oxm_tlv):
@@ -301,14 +355,20 @@ class ipv4_dst(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         if not hasmask:
             oxm_tlv.__init__(self, OFPXMT_OFB_IPV4_DST, hasmask, 4, value)
         else:
             oxm_tlv.__init__(self, OFPXMT_OFB_IPV4_DST, hasmask, 4, value, mask)
     def show(self, prefix=''):
-        outstr = prefix + "ipv4_dst\n"
+        outstr = prefix + "name = ipv4_dst\n"
         outstr += oxm_tlv.show(self, prefix)
+        #Value can be a long int or a string
+        #try:
+        addr = ipaddr.IPv4Address(self.value)
+        #except ValueError:
+         #   addr = ipaddr.IPv4Address(int(self.value, 16))
+        outstr += prefix + "value = " + str(addr) +"\n"
         return outstr
         
 class tcp_src(oxm_tlv):
@@ -322,11 +382,12 @@ class tcp_src(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_TCP_SRC, hasmask, 2, value)
     def show(self, prefix=''):
-        outstr = prefix + "tcp_src\n"
+        outstr = prefix + "name = tcp_src\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr
 
 class tcp_dst(oxm_tlv):
@@ -340,11 +401,12 @@ class tcp_dst(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_TCP_DST, hasmask, 2, value)
     def show(self, prefix=''):
-        outstr = prefix + "tcp_dst\n"
+        outstr = prefix + "name = tcp_dst\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr      
 
 class udp_src(oxm_tlv):
@@ -358,11 +420,12 @@ class udp_src(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_UDP_SRC, hasmask, 2, value)
     def show(self, prefix=''):
-        outstr = prefix + "udp_src\n"
+        outstr = prefix + "name = udp_src\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr   
         
 class udp_dst(oxm_tlv):
@@ -376,11 +439,12 @@ class udp_dst(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_UDP_DST, hasmask, 2, value)
     def show(self, prefix=''):
-        outstr = prefix + "udp_dst\n"
+        outstr = prefix + "name = udp_dst\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr 
         
 class sctp_src(oxm_tlv):
@@ -394,11 +458,12 @@ class sctp_src(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_SCTP_SRC, hasmask, 2, value)
     def show(self, prefix=''):
-        outstr = prefix + "sctp_src\n"
+        outstr = prefix + "name = sctp_src\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr  
 
 
@@ -413,11 +478,12 @@ class sctp_dst(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_SCTP_DST, hasmask, 2, value)
     def show(self, prefix=''):
-        outstr = prefix + "sctp_dst\n"
+        outstr = prefix + "name = sctp_dst\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr         
   
 class icmpv4_type(oxm_tlv):
@@ -431,11 +497,12 @@ class icmpv4_type(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_ICMPV4_TYPE, hasmask, 1, value)
     def show(self, prefix=''):
-        outstr = prefix + "icmpv4_type\n"
+        outstr = prefix + "name = icmpv4_type\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr          
 
 class icmpv4_code(oxm_tlv):
@@ -449,11 +516,12 @@ class icmpv4_code(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_ICMPV4_CODE, hasmask, 1, value)
     def show(self, prefix=''):
-        outstr = prefix + "icmpv4_code\n"
+        outstr = prefix + "name = icmpv4_code\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outs
         
 class arp_op(oxm_tlv):
@@ -467,11 +535,12 @@ class arp_op(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_ARP_OP, hasmask, 2, value)
     def show(self, prefix=''):
-        outstr = prefix + "arp_op\n"
+        outstr = prefix + "name = arp_op\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outs
 
 class arp_spa(oxm_tlv):
@@ -485,14 +554,20 @@ class arp_spa(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         if not hasmask:
             oxm_tlv.__init__(self, OFPXMT_OFB_ARP_SPA, hasmask, 4, value)
         else: 
             oxm_tlv.__init__(self, OFPXMT_OFB_ARP_SPA, hasmask, 4, value, mask)
     def show(self, prefix=''):
-        outstr = prefix + "arp_spa\n"
+        outstr = prefix + "name = arp_spa\n"
+        #Value can be a long int or a string        
+        try:
+            addr = ipaddr.IPv4Address(self.value)
+        except ValueError:
+            addr = ipaddr.IPv4Address(int(self.value, 16))        
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(addr) +"\n"        
         return outstr
         
 class arp_tpa(oxm_tlv):
@@ -506,14 +581,21 @@ class arp_tpa(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         if not hasmask:
             oxm_tlv.__init__(self, OFPXMT_OFB_ARP_TPA, hasmask, 4, value)
         else: 
             oxm_tlv.__init__(self, OFPXMT_OFB_ARP_TPA, hasmask, 4, value, mask)
     def show(self, prefix=''):
-        outstr = prefix + "arp_tpa\n"
+        outstr = prefix + "name = arp_tpa\n"
+        #Value can be a long int or a string        
+        try:
+            addr = ipaddr.IPv4Address(self.value)
+        except ValueError:
+            addr = ipaddr.IPv4Address(int(self.value, 16))
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + ":".join(["%.2x" %x 
+            for x in self.value]) +"\n"                           
         return outstr
 
 
@@ -528,14 +610,16 @@ class arp_sha(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         if not hasmask:
             oxm_tlv.__init__(self, OFPXMT_OFB_ARP_SHA, hasmask, 6, value)
         else:
             oxm_tlv.__init__(self, OFPXMT_OFB_ARP_SHA, hasmask, 12, value)            
     def show(self, prefix=''):
-        outstr = prefix + "arp_sha\n"
+        outstr = prefix + "name = arp_sha\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + ":".join(["%.2x" %x 
+            for x in self.value]) +"\n"        
         return outstr
  
 class arp_tha(oxm_tlv):
@@ -549,14 +633,15 @@ class arp_tha(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         if not hasmask:
             oxm_tlv.__init__(self, OFPXMT_OFB_ARP_THA, hasmask, 6, value)
         else:
             oxm_tlv.__init__(self, OFPXMT_OFB_ARP_THA, hasmask, 12, value)            
     def show(self, prefix=''):
-        outstr = prefix + "arp_tha\n"
+        outstr = prefix + "name = arp_tha\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr
         
 class ipv6_src(oxm_tlv):
@@ -570,14 +655,19 @@ class ipv6_src(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         if not hasmask:
             oxm_tlv.__init__(self, OFPXMT_OFB_IPV6_SRC, False, 16, value)
         else:
             oxm_tlv.__init__(self, OFPXMT_OFB_IPV6_SRC, True, 32, value)            
     def show(self, prefix=''):
-        outstr = prefix + "ipv6_src\n"
+        outstr = prefix + "name = ipv6_src\n"
+        try:
+            addr = ipaddr.IPv6Address(self.value)
+        except ValueError:
+            addr = ipaddr.IPv6Address(int(self.value, 16))             
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(addr) +"\n"        
         return outstr
         
 class ipv6_dst(oxm_tlv):
@@ -591,14 +681,19 @@ class ipv6_dst(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         if not hasmask:
             oxm_tlv.__init__(self, OFPXMT_OFB_IPV6_DST, False, 16, value)
         else:
             oxm_tlv.__init__(self, OFPXMT_OFB_IPV6_DST, True, 32, value)            
     def show(self, prefix=''):
-        outstr = prefix + "ipv6_dst\n"
+        outstr = prefix + "name = ipv6_dst\n"
+        try:
+            addr = ipaddr.IPv6Address(self.value)
+        except ValueError:
+            addr = ipaddr.IPv6Address(int(self.value, 16))             
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(addr) +"\n"        
         return outstr
  
 class ipv6_flabel(oxm_tlv):
@@ -612,13 +707,13 @@ class ipv6_flabel(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         if not hasmask:
             oxm_tlv.__init__(self, OFPXMT_OFB_IPV6_FLABEL, hasmask, 4, value)
         else:
             oxm_tlv.__init__(self, OFPXMT_OFB_IPV6_FLABEL, hasmask, 8, value)            
     def show(self, prefix=''):
-        outstr = prefix + "ipv6_flabel\n"
+        outstr = prefix + "name = ipv6_flabel\n"
         outstr += oxm_tlv.show(self, prefix)
         return outstr
 
@@ -633,11 +728,12 @@ class icmpv6_type(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_ICMPV6_TYPE, hasmask, 1, value)
     def show(self, prefix=''):
-        outstr = prefix + "icmpv6_type\n"
+        outstr = prefix + "name = icmpv6_type\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr          
 
 class icmpv6_code(oxm_tlv):
@@ -651,11 +747,12 @@ class icmpv6_code(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_ICMPV6_CODE, hasmask, 1, value)
     def show(self, prefix=''):
-        outstr = prefix + "icmpv6_code\n"
+        outstr = prefix + "name = icmpv6_code\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outs
 
 class ipv6_nd_target(oxm_tlv):
@@ -669,11 +766,16 @@ class ipv6_nd_target(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_IPV6_ND_TARGET, hasmask, 16, value)
     def show(self, prefix=''):
-        outstr = prefix + "ipv6_nd_target\n"
+        outstr = prefix + "name = ipv6_nd_target\n"
+        try:
+            addr = ipaddr.IPv6Address(self.value)
+        except ValueError:
+            addr = ipaddr.IPv6Address(int(self.value, 16))             
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(addr) +"\n"    
         return outstr
         
 class ipv6_nd_sll(oxm_tlv):
@@ -687,11 +789,12 @@ class ipv6_nd_sll(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_IPV6_ND_SLL, hasmask, 6, value)
     def show(self, prefix=''):
-        outstr = prefix + "ipv6_nd_sll\n"
+        outstr = prefix + "name = ipv6_nd_sll\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr
 
 class ipv6_nd_tll(oxm_tlv):
@@ -705,11 +808,12 @@ class ipv6_nd_tll(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_IPV6_ND_TLL, hasmask, 6, value)          
     def show(self, prefix=''):
-        outstr = prefix + "ipv6_nd_tll\n"
+        outstr = prefix + "name = ipv6_nd_tll\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr
 
 class mpls_label(oxm_tlv):
@@ -723,11 +827,12 @@ class mpls_label(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_MPLS_LABEL, hasmask, 4, value)
     def show(self, prefix=''):
-        outstr = prefix + "mpls_label\n"
+        outstr = prefix + "name = mpls_label\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr
         
 class mpls_tc(oxm_tlv):
@@ -741,11 +846,12 @@ class mpls_tc(oxm_tlv):
     @arg body
 
     """
-    def __init__(self, value, hasmask = False):
+    def __init__(self, value=None, hasmask=False):
         oxm_tlv.__init__(self, OFPXMT_OFB_MPLS_TC, hasmask, 1, value)
     def show(self, prefix=''):
-        outstr = prefix + "mpls_tc\n"
+        outstr = prefix + "name = mpls_tc\n"
         outstr += oxm_tlv.show(self, prefix)
+        outstr += prefix + "value = " + str(self.value) +"\n"
         return outstr
 
 match_class_list = (

--- a/src/python/of12/match_list.py
+++ b/src/python/of12/match_list.py
@@ -1,7 +1,7 @@
 import struct
+import binascii
 import match as match
-from match import oxm_tlv
-from binascii import b2a_hex
+from match import oxm_tlv 
 from base_list import ofp_base_list
 
 
@@ -15,31 +15,76 @@ class match_list(ofp_base_list):
 
     def __len__(self):
         return sum([len(i) for i in self])
-    
+
+    def __eq__(self, other):
+        self.tlvs.sort(key=lambda x: x.field); 
+        other.tlvs.sort(key=lambda x: x.field);
+        return self.tlvs == other.tlvs
+
     def unpack(self, binary_string, bytes=None):
+        oxm_tlv.factory()
         if bytes <= 4:
             return binary_string[4:]
         if bytes == None:
             bytes = len(binary_string)
         offset = 0
         cur_string = binary_string
+        part = lambda: cur_string[read+4:read+4+oxm_length]
         while offset < bytes:
             read = 0
-            oxm_class, oxm_fieldhm, oxm_length = struct.unpack("!HBB", cur_string[read:read+4])   
+            oxm_class, oxm_fieldhm, oxm_length = struct.unpack("!HBB", 
+                cur_string[read:read+4])   
             #Found padding bytes?
             if not oxm_class:
                 break
             oxm_field = oxm_fieldhm >> 1
             oxm_hasmask = oxm_fieldhm & 0x00000001
-            payload = struct.unpack("!" + str(oxm_length) + "s", cur_string[read+4:read+4+oxm_length])[0]
-            if oxm_hasmask:
-                value, mask = payload[:oxm_length/2], payload[oxm_length/2:]    
-            else: 
-                value, mask = payload, None
-            oxm = oxm_tlv(oxm_field, oxm_hasmask, oxm_length, value,mask, oxm_class)
+
+            if oxm_length == 1:
+                if oxm_hasmask:
+                    value, mask = struct.unpack("BB", part())[:2]
+                else: 
+                    value = struct.unpack("!B", part())[0]
+                    mask = None
+            elif  oxm_length == 2 or (oxm_length == 4 and oxm_hasmask == True):
+                if oxm_hasmask:
+                    value, mask = struct.unpack("!HH", part())[:2]
+                else:
+                    value = struct.unpack("!H", part())[0]
+                    mask = None    
+            elif oxm_length == 4 or (oxm_length == 8 and oxm_hasmask == True):
+                if oxm_hasmask:
+                    value, mask = struct.unpack("!II", part())[:2]
+                else: 
+                    value = struct.unpack("!I", part())[0]
+                    mask = None
+            elif oxm_length == 6 or oxm_length == 12:
+                if oxm_hasmask:
+                    data = struct.unpack("!12B", part())[0]
+                    value, mask = data[:6], data[6:]
+                else:
+                    value =  list(struct.unpack("!6B", part()))
+                    mask = None
+            elif oxm_length == 8 or (oxm_length == 16 and oxm_hasmask == True):
+                if oxm_hasmask:
+                    value, mask = struct.unpack("!QQ", part())[0]
+                else: 
+                    value = struct.unpack("!Q", part())[0]
+                    mask = None
+            elif oxm_length == 16 or oxm_length == 32:
+                if oxm_hasmask:
+                    data =  struct.unpack("!32s", part())[0]
+                    value, mask = data[:16], data[16:]
+                else:
+                    value =  struct.unpack("!16s", part())[0]
+                    mask = None             
+          
+            oxm = oxm_tlv.create(oxm_field)
+            oxm.set_hasmask(oxm_hasmask)
+            oxm.set_value(value)
+            oxm.set_mask(mask)
             self.tlvs.append(oxm)
             read = 4 + oxm_length
             offset += read
-            cur_string = cur_string[read:]
-            
+            cur_string = cur_string[read:]   
         return cur_string

--- a/tests-1.2/flow_mods.py
+++ b/tests-1.2/flow_mods.py
@@ -43,6 +43,7 @@ class FlowMod_ModifyStrict(base_tests.SimpleProtocol):
                          "Expected only one flow_mod")
         stat = flow_stats.stats[0]
         self.assertEqual(stat.match, fm_new.match)
+        self.assertEqual(stat.match_fields, fm_new.match_fields)
         self.assertEqual(stat.instructions, fm_new.instructions)
         # @todo consider adding more tests here
         

--- a/tests-1.2/groups.py
+++ b/tests-1.2/groups.py
@@ -161,7 +161,7 @@ class GroupTest(base_tests.SimpleDataPlane):
 
 
     def send_data(self, packet, in_port):
-        self.logger.debug("Send packet on port " + str(in_port))
+        logging.debug("Send packet on port " + str(in_port))
         self.dataplane.send(in_port, str(packet))
 
 


### PR DESCRIPTION
### Changes
- On match unpack, insert the proper match tlv object (e.g, if the oxm field is
  an inport, insert and inport object).
- Add a compare method to oxm_tlvs and match_list, because there was not how to test
  if the match in messages like flow_stats or flow_removed were correctly sent by the switch.
- Parsing of value on match unpack does not return a string value, due to problems when comparing a message created in the controller side and the message sent by the switch.
- Improvements to the print format of oxm_tlvs, easing the debug of messages containing it.

Also, there is a minor fix for the groups test.
