### PR TITLE
testutils: add verify_packet_in and verify_no_packet_in

### DIFF
--- a/tests/actions.py
+++ b/tests/actions.py
@@ -66,9 +66,7 @@ class NoAction(base_tests.SimpleDataPlane):
                 "Packet received on port " + str(rcv_port))
 
         #Verify packets not sent on control plane either
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN, timeout=1)
-        self.assertTrue(response is None,
-                        'Packets not received on control plane')
+        verify_no_packet_in(self, str(pkt), of_ports[0])
 
 
 class Announcement(base_tests.SimpleDataPlane):
@@ -215,9 +213,7 @@ class ForwardController(base_tests.SimpleDataPlane):
             self.dataplane.send(ingress_port, str(pkt))
 
             #Verifying packet recieved on the control plane port
-            (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN, timeout=10)
-            self.assertTrue(response is not None,
-                        'Packet in message not received by controller')
+            verify_packet_in(self, str(pkt), ingress_port, ofp.OFPR_ACTION)
     
 
 

--- a/tests/basic.py
+++ b/tests/basic.py
@@ -91,29 +91,7 @@ class PacketIn(base_tests.SimpleDataPlane):
 
                logging.info("PKT IN test with %s, port %s" % (pt, of_port))
                self.dataplane.send(of_port, str(pkt))
-               #@todo Check for unexpected messages?
-               count = 0
-               while True:
-                   (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN)
-                   if not response:  # Timeout
-                       break
-                   if dataplane.match_exp_pkt(pkt, response.data): # Got match
-                       break
-                   if not config["relax"]:  # Only one attempt to match
-                       break
-                   count += 1
-                   if count > 10:   # Too many tries
-                       break
-
-               self.assertTrue(response is not None, 
-                               'Packet in message not received on port ' + 
-                               str(of_port))
-               if not dataplane.match_exp_pkt(pkt, response.data):
-                   logging.debug("Sent %s" % format_packet(pkt))
-                   logging.debug("Resp %s" % format_packet(response.data))
-                   self.assertTrue(False,
-                                   'Response packet does not match send packet' +
-                                   ' for port ' + str(of_port))
+               verify_packet_in(self, str(pkt), of_port, ofp.OFPR_NO_MATCH)
 
 class PacketInBroadcastCheck(base_tests.SimpleDataPlane):
     """

--- a/tests/default_drop.py
+++ b/tests/default_drop.py
@@ -23,21 +23,6 @@ class PacketInDefaultDrop(base_tests.SimpleDataPlane):
         do_barrier(self.controller)
 
         for of_port in config["port_map"].keys():
-            pkt = simple_tcp_packet()
-            self.dataplane.send(of_port, str(pkt))
-            count = 0
-            while True:
-                (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN)
-                if not response:  # Timeout
-                    break
-                if dataplane.match_exp_pkt(pkt, response.data): # Got match
-                    break
-                if not config["relax"]:  # Only one attempt to match
-                    break
-                count += 1
-                if count > 10:   # Too many tries
-                    break
-
-            self.assertTrue(response is None, 
-                            'Packet in message received on port ' + 
-                            str(of_port))
+            pkt = str(simple_tcp_packet())
+            self.dataplane.send(of_port, pkt)
+            verify_no_packet_in(self, pkt, of_port)

--- a/tests/flow_matches.py
+++ b/tests/flow_matches.py
@@ -115,9 +115,7 @@ class EthernetSrcAddress(base_tests.SimpleDataPlane):
         #Sending non matching packet , verify Packetin event gets triggered.
         pkt2 = simple_eth_packet(eth_src='00:01:01:01:01:02');
         self.dataplane.send(of_ports[0], str(pkt2))
-        
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packets")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
 class EthernetDstAddress(base_tests.SimpleDataPlane):
     
@@ -156,8 +154,7 @@ class EthernetDstAddress(base_tests.SimpleDataPlane):
         self.dataplane.send(of_ports[0], str(pkt2))
         
         #Verify PacketIn event gets triggered
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
 
 class EthernetType(base_tests.SimpleDataPlane):
@@ -197,8 +194,7 @@ class EthernetType(base_tests.SimpleDataPlane):
         self.dataplane.send(of_ports[0], str(pkt2))
         
         #verify Packetin event gets triggered.
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non-matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
             
 class IngressPort(base_tests.SimpleDataPlane):
@@ -237,8 +233,7 @@ class IngressPort(base_tests.SimpleDataPlane):
         self.dataplane.send(of_ports[1],str(pkt))
 
         #Verify PacketIn event gets triggered
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non-matching packet")
+        verify_packet_in(self, str(pkt), of_ports[1], ofp.OFPR_NO_MATCH)
 
 class VlanId(base_tests.SimpleDataPlane):
 
@@ -275,8 +270,7 @@ class VlanId(base_tests.SimpleDataPlane):
         self.dataplane.send(of_ports[0], str(pkt2))
         
         #Verify PacketIn event gets triggered
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
 class VlanPCP(base_tests.SimpleDataPlane):
 
@@ -315,8 +309,7 @@ class VlanPCP(base_tests.SimpleDataPlane):
         self.dataplane.send(of_ports[0], str(pkt2))
 
         #Verify Packet_In event gets triggered
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
        
 class MultipleHeaderFieldL2(base_tests.SimpleDataPlane):
     
@@ -352,24 +345,19 @@ class MultipleHeaderFieldL2(base_tests.SimpleDataPlane):
         #Sending non matching packet (only eth_dst is different) , verify Packetin event gets triggered.
         pkt2 = simple_eth_packet(eth_type=0x88cc,eth_src='00:01:01:01:01:01',eth_dst='00:01:01:02:01:01');
         self.dataplane.send(of_ports[0], str(pkt2))
-        
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
         #Sending non matching packet (only eth_src is different) , verify Packetin event gets triggered.
         pkt2 = simple_eth_packet(eth_type=0x88cc,eth_src='00:01:01:01:01:02',eth_dst='00:01:01:01:01:02');
         self.dataplane.send(of_ports[0], str(pkt2))
-        
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
         #Sending non matching packet (only ether_type is different) , verify Packetin event gets triggered.
         pkt2 = simple_eth_packet(eth_type=0x0806,eth_src='00:01:01:01:01:01',eth_dst='00:01:01:01:01:02');
         self.dataplane.send(of_ports[0], str(pkt2))
         
         #Verify packet_in event gets triggered
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
 class IpTos(base_tests.SimpleDataPlane):
 
@@ -406,8 +394,7 @@ class IpTos(base_tests.SimpleDataPlane):
         #Create a non-matching packet , verify packet_in get generated
         pkt2 = simple_tcp_packet(ip_tos=4);
         self.dataplane.send(of_ports[0], str(pkt2))
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
 class IpProtocol(base_tests.SimpleDataPlane):
 
@@ -444,8 +431,7 @@ class IpProtocol(base_tests.SimpleDataPlane):
         #Create a non-matching packet , verify packet_in get generated
         pkt2 = simple_icmp_packet();
         self.dataplane.send(of_ports[0], str(pkt2))
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
 
 class TcpSrcPort(base_tests.SimpleDataPlane):
@@ -482,9 +468,7 @@ class TcpSrcPort(base_tests.SimpleDataPlane):
         #Sending non matching packet , verify Packetin event gets triggered.
         pkt2 = simple_tcp_packet(tcp_sport=540);
         self.dataplane.send(of_ports[0], str(pkt2))
-        
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
 class TcpDstPort(base_tests.SimpleDataPlane):
     
@@ -520,9 +504,7 @@ class TcpDstPort(base_tests.SimpleDataPlane):
         #Sending non matching packet , verify Packetin event gets triggered.
         pkt2 = simple_tcp_packet(tcp_dport=541);
         self.dataplane.send(of_ports[0], str(pkt2))
-        
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=10)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
 class UdpSrcPort(base_tests.SimpleDataPlane):
     
@@ -558,9 +540,7 @@ class UdpSrcPort(base_tests.SimpleDataPlane):
         #Sending non matching packet , verify Packetin event gets triggered.
         pkt2 = simple_udp_packet(udp_sport=540);
         self.dataplane.send(of_ports[0], str(pkt2))
-        
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
 class UdpDstPort(base_tests.SimpleDataPlane):
     
@@ -596,9 +576,7 @@ class UdpDstPort(base_tests.SimpleDataPlane):
         #Sending non matching packet , verify Packetin event gets triggered.
         pkt2 = simple_udp_packet(udp_dport=541);
         self.dataplane.send(of_ports[0], str(pkt2))
-        
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=10)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
 class ICMPType(base_tests.SimpleDataPlane):
     
@@ -634,9 +612,7 @@ class ICMPType(base_tests.SimpleDataPlane):
         #Sending non matching packet , verify Packetin event gets triggered.
         pkt2 = simple_icmp_packet(icmp_type=10);
         self.dataplane.send(of_ports[0], str(pkt2))
-        
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
 class ICMPCode(base_tests.SimpleDataPlane):
     
@@ -672,9 +648,7 @@ class ICMPCode(base_tests.SimpleDataPlane):
         #Sending non matching packet , verify Packetin event gets triggered.
         pkt2 = simple_icmp_packet(icmp_code=10);
         self.dataplane.send(of_ports[0], str(pkt2))
-        
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
 
 class ArpSenderIP(base_tests.SimpleDataPlane):
@@ -712,8 +686,7 @@ class ArpSenderIP(base_tests.SimpleDataPlane):
         #Create a non-matching packet , verify packet_in get generated
         pkt2 = simple_arp_packet(ip_snd="10.10.0.10");
         self.dataplane.send(of_ports[0], str(pkt2))
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
 class ArpTargetIP(base_tests.SimpleDataPlane):
 
@@ -750,8 +723,7 @@ class ArpTargetIP(base_tests.SimpleDataPlane):
         #Create a non-matching packet , verify packet_in get generated
         pkt2 = simple_arp_packet(ip_tgt="10.10.0.10");
         self.dataplane.send(of_ports[0], str(pkt2))
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
 
 class ExactMatch(base_tests.SimpleDataPlane):
@@ -788,9 +760,7 @@ class ExactMatch(base_tests.SimpleDataPlane):
         #Sending non matching packet , verify Packetin event gets triggered.
         pkt2 = simple_tcp_packet(tcp_sport=540);
         self.dataplane.send(of_ports[0], str(pkt2))
-        
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
 
 class MultipleHeaderFieldL4(base_tests.SimpleDataPlane):
@@ -827,16 +797,12 @@ class MultipleHeaderFieldL4(base_tests.SimpleDataPlane):
         #Sending non matching packet (tcp_dport different), verify Packetin event gets triggered.
         pkt2 = simple_tcp_packet(tcp_sport=111,tcp_dport=541);
         self.dataplane.send(of_ports[0], str(pkt2))
-        
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
         #Sending non matching packet (tcp_sport different), verify Packetin event gets triggered.
         pkt2 = simple_tcp_packet(tcp_sport=100,tcp_dport=112);
         self.dataplane.send(of_ports[0], str(pkt2))
-        
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN,timeout=4)
-        self.assertTrue(response is not None, "PacketIn not received for non matching packet")
+        verify_packet_in(self, str(pkt2), of_ports[0], ofp.OFPR_NO_MATCH)
 
 
 class ExactMatchPrio(base_tests.SimpleDataPlane):

--- a/tests/message_types.py
+++ b/tests/message_types.py
@@ -316,9 +316,7 @@ class PacketInSizeMiss(base_tests.SimpleDataPlane):
             self.dataplane.send(of_ports[0],str(pkt))
 
             #Verify packet_in generated
-            (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN, timeout=3)
-            self.assertTrue(response is not None,
-                        'Packet In not received on control plane')
+            response = verify_packet_in(self, str(pkt), of_ports[0], ofp.OFPR_NO_MATCH)
 
             #Verify buffer_id field and data field
             if response.buffer_id == 0xFFFFFFFF:
@@ -375,12 +373,7 @@ class PacketInSizeAction(base_tests.SimpleDataPlane):
             self.dataplane.send(of_ports[0], str(pkt))
 
             #Verifying packet_in recieved on the control plane 
-            (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN, timeout=10)
-            self.assertTrue(response is not None,
-                        'Packet in message not received by controller')
-
-            #Verify the reason field is OFPR_ACTION
-            self.assertEqual(response.reason,ofp.OFPR_ACTION,"PacketIn reason field is incorrect")
+            response = verify_packet_in(self, str(pkt), of_ports[0], ofp.OFPR_ACTION)
 
             #Verify buffer_id field and data field
             if response.buffer_id != 0xFFFFFFFF :
@@ -419,18 +412,10 @@ class PacketInBodyMiss(base_tests.SimpleDataPlane):
         self.dataplane.send(of_ports[0],str(pkt))
 
         #Verify packet_in generated
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN, timeout=3)
-        self.assertTrue(response is not None,
-                        'Packet In not received on control plane')
+        response = verify_packet_in(self, str(pkt), of_ports[0], ofp.OFPR_NO_MATCH)
 
         #Verify Frame Total Length Field in Packet_in 
         self.assertEqual(response.total_len,len(str(pkt)), "PacketIn total_len field is incorrect")
-
-        #Verify in_port field in Packet_in
-        self.assertEqual(response.in_port,of_ports[0],"PacketIn in_port or recieved port field is incorrect")
-
-        #Verify the reason field in Packet_in is OFPR_NO_MATCH
-        self.assertEqual(response.reason,ofp.OFPR_NO_MATCH,"PacketIn reason field is incorrect")
 
         #Verify data field 
         self.assertTrue(len(response.data) == len(str(pkt)), "Complete Data packet was not sent")
@@ -473,21 +458,13 @@ class PacketInBodyAction(base_tests.SimpleDataPlane):
         self.dataplane.send(of_ports[0], str(pkt))
 
         #Verifying packet_in recieved on the control plane 
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN, timeout=10)
-        self.assertTrue(response is not None,
-                    'Packet in message not received by controller')
-
-        #Verify the reason field is OFPR_ACTION
-        self.assertEqual(response.reason,ofp.OFPR_ACTION,"PacketIn reason field is incorrect")
+        response = verify_packet_in(self, str(pkt), of_ports[0], ofp.OFPR_ACTION)
 
         #Verify Frame Total Length Field in Packet_in 
         self.assertEqual(response.total_len,len(str(pkt)), "PacketIn total_len field is incorrect")
 
         #verify the data field
         self.assertEqual(len(response.data),len(str(pkt)),"Complete Data Packet was not sent")
-
-        #Verify in_port field in Packet_in
-        self.assertEqual(response.in_port,of_ports[0],"PacketIn in_port or recieved port field is incorrect")
 
 
 @nonstandard

--- a/tests/openflow_protocol_messages.py
+++ b/tests/openflow_protocol_messages.py
@@ -275,10 +275,7 @@ class PacketIn(base_tests.SimpleDataPlane):
         logging.info("Sending packet to dp port " + str(ingress_port) +
                    ", expecting packet_in on control plane" )
       
-        (response, pkt) = self.controller.poll(exp_msg=ofp.OFPT_PACKET_IN,
-                                               timeout=2)
-        self.assertTrue(response is not None, 
-                               'Packet in event is not sent to the controller') 
+        verify_packet_in(self, str(pkt), ingress_port, ofp.OFPR_NO_MATCH)
 
 
 class Hello(base_tests.SimpleDataPlane):

--- a/tests/pktact.py
+++ b/tests/pktact.py
@@ -196,17 +196,7 @@ class DirectPacketController(base_tests.SimpleDataPlane):
                         str(ingress_port))
         self.dataplane.send(ingress_port, str(pkt))
 
-        (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN)
-
-        self.assertTrue(response is not None,
-                        'Packet in message not received by controller')
-        if not dataplane.match_exp_pkt(pkt, response.data):
-            logging.debug("Sent %s" % format_packet(pkt))
-            logging.debug("Resp %s" % format_packet(response.data))
-            self.assertTrue(False,
-                            'Response packet does not match send packet' +
-                             ' for controller port')
-
+        verify_packet_in(self, str(pkt), ingress_port, ofp.OFPR_ACTION)
 
 class DirectPacketQueue(base_tests.SimpleDataPlane):
     """
@@ -419,31 +409,8 @@ class DirectPacketControllerQueue(base_tests.SimpleDataPlane):
                 logging.info("Sending packet to dp port " + 
                                str(ingress_port))
                 self.dataplane.send(ingress_port, str(pkt))
-                
-                exp_pkt_arg = None
-                exp_port = None
 
-                count = 0
-                while True:
-                    (response, raw) = self.controller.poll(ofp.OFPT_PACKET_IN)
-                    if not response:  # Timeout
-                        break
-                    if dataplane.match_exp_pkt(pkt, response.data): # Got match
-                        break
-                    if not config["relax"]:  # Only one attempt to match
-                        break
-                    count += 1
-                    if count > 10:   # Too many tries
-                        break
-
-                self.assertTrue(response is not None, 
-                               'Packet in message not received by controller')
-                if not dataplane.match_exp_pkt(pkt, response.data):
-                    logging.debug("Sent %s" % format_packet(pkt))
-                    logging.debug("Resp %s" % format_packet(response.data))
-                    self.assertTrue(False,
-                                    'Response packet does not match send packet' +
-                                    ' for controller port')
+                verify_packet_in(self, str(pkt), ingress_port, ofp.OFPR_ACTION)
 
                 # FIXME: instead of sleeping, keep requesting queue stats until
                 # the expected queue counter increases or some large timeout is


### PR DESCRIPTION
Reviewer: @eswierk

Checking that the controller received a packet-in message is surprisingly
complicated to do correctly. Because the switch may send unexpected packet-ins
(Linux IP stack on IVS's OFPP_LOCAL, for example) each test needs logic to
match the packet data, in_port, etc to figure out if this is the packet-in
message it's looking for.

This change adds two testutils functions that automate this, and replaces all
the other implementations in tests.
