### PR TITLE
testutils: send barrier after deleting all flows

### DIFF
--- a/src/python/oftest/testutils.py
+++ b/src/python/oftest/testutils.py
@@ -44,6 +44,7 @@ def delete_all_flows(ctrl):
     msg.out_port = ofp.OFPP_NONE
     msg.buffer_id = 0xffffffff
     ctrl.message_send(msg)
+    do_barrier(ctrl)
     return 0 # for backwards compatibility
 
 def required_wildcards(parent):


### PR DESCRIPTION
Reviewer: trivial

If a flow-add is sent immediately after a flow-delete-all, the switch can 
legitimately include the new flow in the set of flows deleted. A barrier must 
be used to serialize these operations.
