### PR TITLE
testutils: use unicast MACs in simple_eth_pkt

### DIFF
--- a/src/python/oftest/testutils.py
+++ b/src/python/oftest/testutils.py
@@ -418,8 +418,8 @@ def simple_arp_packet(pktlen=60,
     return pkt
 
 def simple_eth_packet(pktlen=60,
-                      eth_dst='01:80:c2:00:00:00',
-                      eth_src='00:01:02:03:04:05',
+                      eth_dst='00:01:02:03:04:05',
+                      eth_src='00:06:07:08:09:0a',
                       eth_type=0x88cc):
 
     if MINSIZE > pktlen:


### PR DESCRIPTION
Reviewer: trivial

This "simple" function shouldn't create multicast packets. Changed to use the 
same MACs as the other packet creation functions.

Reported by Tony van der Peet tony.vanderpeet@gmail.com.
