### PR TITLE
Verify capability

### DIFF
--- a/src/python/oftest/testutils.py
+++ b/src/python/oftest/testutils.py
@@ -1689,7 +1689,7 @@ def verify_no_errors(ctrl):
 
 def verify_capability(test, capability):
     """
-    Assert that the DUT supports the specified capability.
+    Return True if DUT supports the specified capability.
 
     @param test Instance of base_tests.SimpleProtocol
     @param capability One of ofp_capabilities.


### PR DESCRIPTION
Removing assertion in case bit is not set. It may be the case that a capability is not supported, but still conformant to specification. Test cases should fail only if exhibiting non-conformant behavior.
