### PR TITLE
dataplane: copy buffer returned by pypcap

### DIFF
--- a/src/python/oftest/dataplane.py
+++ b/src/python/oftest/dataplane.py
@@ -126,7 +126,7 @@ class DataPlanePortPcap:
 
     def recv(self):
         (timestamp, pkt) = next(self.pcap)
-        return (pkt, timestamp)
+        return (pkt[:], timestamp)
 
     def send(self, packet):
         return self.pcap.inject(packet, len(packet))


### PR DESCRIPTION
Reviewer: @wilmo119

When reading packets pypcap always returns a pointer to the same statically 
allocated memory, which will be overwritten the next time a packet is read. I 
believe this is a bug in pypcap. The workaround is to make a copy immediately.
