### PR TITLE
Add XML support

### DIFF
--- a/oft
+++ b/oft
@@ -573,8 +573,12 @@ if __name__ == "__main__":
 
     logging.info("*** TEST RUN START: " + time.asctime())
     if config["xunit"]:
-        import xmlrunner  # fail-fast if module missing
-
+        try:
+            import xmlrunner  # fail-fast if module missing
+        except ImportError as ex:
+            oftest.dataplane_instance.kill()
+            profiler_teardown(profiler)
+            raise ex
         runner = xmlrunner.XMLTestRunner(output=config["xunit_dir"],
                                          outsuffix="",
                                          verbosity=2)


### PR DESCRIPTION
Resolves #123. Appears to work without issue normally, and fails only if `xunit` option given but required package is missing.

In addition, move profiler setup/teardown to individual functions to reduce some _clutter_ in the main body.
