### PR TITLE
dataplane: support PyPI version of pypcap

### DIFF
--- a/src/python/oftest/dataplane.py
+++ b/src/python/oftest/dataplane.py
@@ -129,7 +129,10 @@ class DataPlanePortPcap:
         return (pkt[:], timestamp)
 
     def send(self, packet):
-        return self.pcap.inject(packet, len(packet))
+        if hasattr(self.pcap, "inject"):
+            return self.pcap.inject(packet, len(packet))
+        else:
+           return self.pcap.sendpacket(packet)
 
     def down(self):
         pass


### PR DESCRIPTION
Reviewer: trivial

The Ubuntu version of pypcap only supports "inject" for sending packets, but 
the upstream verison only supports "sendpacket".