### PR TITLE
Avoid using libpcap on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ The following software is required to run OFTest:
 
  * Python 2.7
  * Scapy
- * pypcap (optional - VLAN tests will fail without this)
  * tcpdump (optional - Scapy will complain if it's missing)
  * Doxygen and doxypy (optional - for documentation generation)
  * PyLint (optional - for source checking)

--- a/src/python/oftest/afpacket.py
+++ b/src/python/oftest/afpacket.py
@@ -98,11 +98,11 @@ def recv(sk, bufsize):
     # only control message.
     assert msghdr.msg_controllen >= sizeof(struct_cmsghdr)
 
-    cmsghdr = struct_cmsghdr.from_buffer(ctrl_buf)
+    cmsghdr = struct_cmsghdr.from_buffer(ctrl_buf) # pylint: disable=no-member
     assert cmsghdr.cmsg_level == SOL_PACKET
     assert cmsghdr.cmsg_type == PACKET_AUXDATA
 
-    auxdata = struct_tpacket_auxdata.from_buffer(ctrl_buf, sizeof(struct_cmsghdr))
+    auxdata = struct_tpacket_auxdata.from_buffer(ctrl_buf, sizeof(struct_cmsghdr)) # pylint: disable=no-member
 
     if auxdata.tp_vlan_tci != 0 or auxdata.tp_status & TP_STATUS_VLAN_VALID:
         # Insert VLAN tag

--- a/src/python/oftest/afpacket.py
+++ b/src/python/oftest/afpacket.py
@@ -98,11 +98,11 @@ def recv(sk, bufsize):
     # only control message.
     assert msghdr.msg_controllen >= sizeof(struct_cmsghdr)
 
-    cmsghdr = struct_cmsghdr.from_buffer(ctrl_buf) # pylint: disable=no-member
+    cmsghdr = struct_cmsghdr.from_buffer(ctrl_buf) # pylint: disable=E1101
     assert cmsghdr.cmsg_level == SOL_PACKET
     assert cmsghdr.cmsg_type == PACKET_AUXDATA
 
-    auxdata = struct_tpacket_auxdata.from_buffer(ctrl_buf, sizeof(struct_cmsghdr)) # pylint: disable=no-member
+    auxdata = struct_tpacket_auxdata.from_buffer(ctrl_buf, sizeof(struct_cmsghdr)) # pylint: disable=E1101
 
     if auxdata.tp_vlan_tci != 0 or auxdata.tp_status & TP_STATUS_VLAN_VALID:
         # Insert VLAN tag

--- a/src/python/oftest/afpacket.py
+++ b/src/python/oftest/afpacket.py
@@ -1,0 +1,112 @@
+"""
+AF_PACKET receive support
+
+When VLAN offload is enabled on the NIC Linux will not deliver the VLAN tag
+in the data returned by recv. Instead, it delivers the VLAN TCI in a control
+message. Python 2.x doesn't have built-in support for recvmsg, so we have to
+use ctypes to call it. The recv function exported by this module reconstructs
+the VLAN tag if it was offloaded.
+"""
+
+import socket
+import struct
+from ctypes import *
+
+ETH_P_8021Q = 0x8100
+SOL_PACKET = 263
+PACKET_AUXDATA = 8
+TP_STATUS_VLAN_VALID = 1 << 4
+
+class struct_iovec(Structure):
+    _fields_ = [
+        ("iov_base", c_void_p),
+        ("iov_len", c_size_t),
+    ]
+
+class struct_msghdr(Structure):
+    _fields_ = [
+        ("msg_name", c_void_p),
+        ("msg_namelen", c_uint32),
+        ("msg_iov", POINTER(struct_iovec)),
+        ("msg_iovlen", c_size_t),
+        ("msg_control", c_void_p),
+        ("msg_controllen", c_size_t),
+        ("msg_flags", c_int),
+    ]
+
+class struct_cmsghdr(Structure):
+    _fields_ = [
+        ("cmsg_len", c_size_t),
+        ("cmsg_level", c_int),
+        ("cmsg_type", c_int),
+    ]
+
+class struct_tpacket_auxdata(Structure):
+    _fields_ = [
+        ("tp_status", c_uint),
+        ("tp_len", c_uint),
+        ("tp_snaplen", c_uint),
+        ("tp_mac", c_ushort),
+        ("tp_net", c_ushort),
+        ("tp_vlan_tci", c_ushort),
+        ("tp_padding", c_ushort),
+    ]
+
+libc = CDLL("libc.so.6")
+recvmsg = libc.recvmsg
+recvmsg.argtypes = [c_int, POINTER(struct_msghdr), c_int]
+recvmsg.retype = c_int
+
+def enable_auxdata(sk):
+    """
+    Ask the kernel to return the VLAN tag in a control message
+
+    Must be called on the socket before afpacket.recv.
+    """
+    sk.setsockopt(SOL_PACKET, PACKET_AUXDATA, 1)
+
+def recv(sk, bufsize):
+    """
+    Receive a packet from an AF_PACKET socket
+    @sk Socket
+    @bufsize Maximum packet size
+    """
+    buf = create_string_buffer(bufsize)
+
+    ctrl_bufsize = sizeof(struct_cmsghdr) + sizeof(struct_tpacket_auxdata) + sizeof(c_size_t)
+    ctrl_buf = create_string_buffer(ctrl_bufsize)
+
+    iov = struct_iovec()
+    iov.iov_base = cast(buf, c_void_p)
+    iov.iov_len = bufsize
+
+    msghdr = struct_msghdr()
+    msghdr.msg_name = None
+    msghdr.msg_namelen = 0
+    msghdr.msg_iov = pointer(iov)
+    msghdr.msg_iovlen = 1
+    msghdr.msg_control = cast(ctrl_buf, c_void_p)
+    msghdr.msg_controllen = ctrl_bufsize
+    msghdr.msg_flags = 0
+
+    rv = recvmsg(sk.fileno(), byref(msghdr), 0)
+    if rv < 0:
+        raise RuntimeError("recvmsg failed: rv=%d", rv)
+
+    # The kernel only delivers control messages we ask for. We
+    # only enabled PACKET_AUXDATA, so we can assume it's the
+    # only control message.
+    assert msghdr.msg_controllen >= sizeof(struct_cmsghdr)
+
+    cmsghdr = struct_cmsghdr.from_buffer(ctrl_buf)
+    assert cmsghdr.cmsg_level == SOL_PACKET
+    assert cmsghdr.cmsg_type == PACKET_AUXDATA
+
+    auxdata = struct_tpacket_auxdata.from_buffer(ctrl_buf, sizeof(struct_cmsghdr))
+
+    if auxdata.tp_vlan_tci != 0 or auxdata.tp_status & TP_STATUS_VLAN_VALID:
+        # Insert VLAN tag
+        tag = struct.pack("!HH", ETH_P_8021Q, auxdata.tp_vlan_tci)
+        return buf.raw[:12] + tag + buf.raw[12:rv]
+    else:
+        return buf.raw[:rv]

--- a/src/python/oftest/dataplane.py
+++ b/src/python/oftest/dataplane.py
@@ -29,15 +29,8 @@ from pcap_writer import PcapWriter
 
 if "linux" in sys.platform:
     import afpacket
-
-have_pypcap = False
-try:
+else:
     import pcap
-    if hasattr(pcap, "pcap"):
-        # the incompatible pylibpcap library masquerades as pcap
-        have_pypcap = True
-except:
-    pass
 
 def match_exp_pkt(exp_pkt, pkt):
     """
@@ -53,7 +46,7 @@ def match_exp_pkt(exp_pkt, pkt):
     return e == p
 
 
-class DataPlanePort:
+class DataPlanePortLinux:
     """
     Uses raw sockets to capture and send packets on a network interface.
     """
@@ -115,10 +108,8 @@ class DataPlanePort:
 
 class DataPlanePortPcap:
     """
-    Alternate port implementation using libpcap. This is required for recent
-    versions of Linux (such as Linux 3.2 included in Ubuntu 12.04) which
-    offload the VLAN tag, so it isn't in the data returned from a read on a raw
-    socket. libpcap understands how to read the VLAN tag from the kernel.
+    Alternate port implementation using libpcap. This is used by non-Linux
+    operating systems.
     """
 
     def __init__(self, interface_name, port_number):
@@ -192,10 +183,10 @@ class DataPlane(Thread):
         #
         if "dataplane" in self.config and "portclass" in self.config["dataplane"]:
             self.dppclass = self.config["dataplane"]["portclass"]
-        elif have_pypcap:
-            self.dppclass = DataPlanePortPcap
+        elif "linux" in sys.platform:
+            self.dppclass = DataPlanePortLinux
         else:
-            self.dppclass = DataPlanePort
+            self.dppclass = DataPlanePortPcap
 
         self.start()
 


### PR DESCRIPTION
Reviewer: @jnealtowns 

Starting with Ubuntu 14.04 libpcap uses the TPACKET_V3 interface to receive packets. TPACKET_V3 is unsuitable for applications with low packet rates that want to receive packets immediately. Newer versions of libpcap have an API `pcap_set_immediate_mode` that reverts to using TPACKET_V2. However, I couldn't find any pcap Python libraries on pip that supported this call. The pypcap package we use is unmaintained, so we can't just add it. My personal workaround of downgrading libpcap isn't scalable.

The original reason we started using libpcap was that it handled VLAN offload and reconstructed the offloaded tag in the packet data. This isn't easy to do in pure Python because the offloaded tag is delivered in a recvmsg control message, but at this point it's easier than fixing pypcap.