### PR TITLE
dataplane: pass protocol number to bind() instead of socket()

### DIFF
--- a/src/python/oftest/dataplane.py
+++ b/src/python/oftest/dataplane.py
@@ -60,10 +60,9 @@ class DataPlanePortLinux:
         @param interface_name The name of the physical interface like eth1
         """
         self.interface_name = interface_name
-        self.socket = socket.socket(socket.AF_PACKET, socket.SOCK_RAW,
-                                    socket.htons(self.ETH_P_ALL))
+        self.socket = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, 0)
         afpacket.enable_auxdata(self.socket)
-        self.socket.bind((interface_name, 0))
+        self.socket.bind((interface_name, self.ETH_P_ALL))
         netutils.set_promisc(self.socket, interface_name)
         self.socket.settimeout(self.RCV_TIMEOUT)
 


### PR DESCRIPTION
Reviewer: @rlane

This makes the bind call much faster because it doesn't need to unregister the 
protocol hook, which requires waiting for an RCU grace period (~10ms). Linux 
3.14 and later optimize this internally, but Ubuntu 14.04 doesn't have a
recent enough kernel.

The Python socket library does the htons for us when creating the sockaddr for 
bind.

This change reduces the time to run IVS automated tests by half.