### PR TITLE
port_stats.AllPortStats: clear flowtable before inserting new flows

### DIFF
--- a/tests/port_stats.py
+++ b/tests/port_stats.py
@@ -301,6 +301,9 @@ class AllPortStats(base_tests.SimpleDataPlane):
         return flow_mod_msg
 
     def runTest(self):
+        delete_all_flows(self.controller)
+        do_barrier(self.controller)
+
         # TODO: set from command-line parameter
         test_timeout = 60
 


### PR DESCRIPTION
Reviewer: trivial

This test was failing due to interference from other tests.