### PR TITLE
fix interactions between stats and packet forwarding testcases

### DIFF
--- a/src/python/oftest/testutils.py
+++ b/src/python/oftest/testutils.py
@@ -1451,23 +1451,25 @@ def verify_port_stats(test, port,
         rx_pkts_diff = rx_pkts_after - rx_pkts_before
         tx_bytes_diff = tx_bytes_after - tx_bytes_before
         rx_bytes_diff = rx_bytes_after - rx_bytes_before
-        if (tx_pkts == None or tx_pkts == tx_pkts_diff) and \
-           (rx_pkts == None or rx_pkts == rx_pkts_diff) and \
+        if (tx_pkts == None or tx_pkts <= tx_pkts_diff) and \
+           (rx_pkts == None or rx_pkts <= rx_pkts_diff) and \
            (tx_bytes == None or tx_bytes <= tx_bytes_diff) and \
            (rx_bytes == None or rx_bytes <= rx_bytes_diff):
             break
         time.sleep(0.1)
 
     if (tx_pkts != None):
-        test.assertEqual(tx_pkts,tx_pkts_diff,"Port TX packet counter is not updated correctly (expected increase of %d, got increase of %d)" % (tx_pkts, tx_pkts_diff))
+        test.assertGreaterEqual(tx_pkts_diff, tx_pkts,
+            "Port TX packet counter is not updated correctly (expected increase of %d, got increase of %d)" % (tx_pkts, tx_pkts_diff))
     if (rx_pkts != None):
-        test.assertEqual(rx_pkts,rx_pkts_diff,"Port RX packet counter is not updated correctly (expected increase of %d, got increase of %d)" % (rx_pkts, rx_pkts_diff))
+        test.assertGreaterEqual(rx_pkts_diff, rx_pkts,
+            "Port RX packet counter is not updated correctly (expected increase of %d, got increase of %d)" % (rx_pkts, rx_pkts_diff))
     if (tx_bytes != None):
-        test.assertTrue(tx_bytes_diff >= tx_bytes and tx_bytes_diff <= tx_bytes*1.1,
-                        "Port TX byte counter is not updated correctly (expected increase of %d, got increase of %d)" % (tx_bytes, tx_bytes_diff))
+        test.assertGreaterEqual(tx_bytes_diff, tx_bytes,
+            "Port TX byte counter is not updated correctly (expected increase of %d, got increase of %d)" % (tx_bytes, tx_bytes_diff))
     if (rx_bytes != None):
-        test.assertTrue(rx_bytes_diff >= rx_bytes and rx_bytes_diff <= rx_bytes*1.1,
-                        "Port RX byte counter is not updated correctly (expected increase of %d, got increase of %d)" % (rx_bytes, rx_bytes_diff))
+        test.assertGreaterEqual(rx_bytes_diff, rx_bytes,
+            "Port RX byte counter is not updated correctly (expected increase of %d, got increase of %d)" % (rx_bytes, rx_bytes_diff))
 
 def verify_queue_stats(test, port_no, queue_id,
                        initial=[],

--- a/tests/FuncUtils.py
+++ b/tests/FuncUtils.py
@@ -412,10 +412,7 @@ def get_flowstats(self,match):
 def get_portstats(self,port_num):
 
 # Return all the port counters in the form a tuple 
-    port_stats_req = ofp.message.port_stats_request()
-    port_stats_req.port_no = port_num  
-    response,pkt = self.controller.transact(port_stats_req)
-    self.assertTrue(response is not None,"No response received for port stats request") 
+    entries = get_port_stats(self, port_num)
     rx_pkts=0
     tx_pkts=0
     rx_byts=0
@@ -431,7 +428,7 @@ def get_portstats(self,port_num):
     tx_err=0
 
 
-    for obj in response.entries:
+    for obj in entries:
         rx_pkts += obj.rx_packets
         tx_pkts += obj.tx_packets
         rx_byts += obj.rx_bytes

--- a/tests/port_stats.py
+++ b/tests/port_stats.py
@@ -110,10 +110,10 @@ def verifyStats(obj, port, test_timeout, packet_sent, packet_recv):
             sent = item.tx_packets
             recv = item.rx_packets
             logging.info("Sent " + str(item.tx_packets) + " packets")
-            if item.tx_packets == packet_sent:
+            if item.tx_packets >= packet_sent:
                 all_packets_sent = 1
             logging.info("Received " + str(item.rx_packets) + " packets")
-            if item.rx_packets == packet_recv:
+            if item.rx_packets >= packet_recv:
                 all_packets_received = 1
 
         if all_packets_received and all_packets_sent:

--- a/tests/port_stats.py
+++ b/tests/port_stats.py
@@ -60,16 +60,8 @@ def sendPacket(obj, pkt, ingress_port, egress_port, test_timeout):
                     'Response packet does not match send packet')
 
 def getStats(obj, port):
-    stat_req = ofp.message.port_stats_request()
-    stat_req.port_no = port
-
-    logging.info("Sending stats request")
-    response, pkt = obj.controller.transact(stat_req, timeout=2)
-    obj.assertTrue(response is not None, 
-                    "No response to stats request")
-    obj.assertTrue(len(response.entries) == 1,
-                    "Did not receive port stats reply")
-    for item in response.entries:
+    entries = get_port_stats(obj, port)
+    for item in entries:
         logging.info("Sent " + str(item.tx_packets) + " packets")
         packet_sent = item.tx_packets
         packet_recv = item.rx_packets
@@ -77,17 +69,9 @@ def getStats(obj, port):
     return packet_sent, packet_recv
 
 def getAllStats(obj):
-    stat_req = ofp.message.port_stats_request()
-    stat_req.port_no = ofp.OFPP_NONE
-
-    logging.info("Sending all port stats request")
-    response, pkt = obj.controller.transact(stat_req, timeout=2)
-    obj.assertTrue(response is not None, 
-                    "No response to stats request")
-    obj.assertTrue(len(response.entries) >= 3,
-                    "Did not receive all port stats reply")
+    entries = get_port_stats(obj, ofp.OFPP_NONE)
     stats = {}
-    for item in response.entries:
+    for item in entries:
         stats[ item.port_no ] = ( item.tx_packets, item.rx_packets )
     return stats
 


### PR DESCRIPTION
Reviewer: @harshsin

A switch that periodically syncs stats to the OpenFlow layer (like IVS) could
fail these stats tests because they didn't account for the delay in the stats
updates from previous tests. They already accounted for the delay in stats for
their own test.