### PR TITLE
tests: add sleep after flow timeouts

### DIFF
--- a/tests/detailed_contr_sw_messages.py
+++ b/tests/detailed_contr_sw_messages.py
@@ -628,6 +628,8 @@ class IdleTimeout(base_tests.SimpleDataPlane):
         self.assertEqual(1, response.duration_sec,
                          'Flow was not alive for 1 sec')
 
+        sleep(1)
+
 
 class Outport2(base_tests.SimpleDataPlane):
 
@@ -710,6 +712,8 @@ class HardTimeout(base_tests.SimpleDataPlane):
         self.assertEqual(1, response.duration_sec,
                          'Flow was not alive for 1 sec')
 
+        sleep(1)
+
 
 class FlowTimeout(base_tests.SimpleDataPlane):
   
@@ -760,6 +764,8 @@ class FlowTimeout(base_tests.SimpleDataPlane):
 
         # Verify no entries in the table
         verify_tablestats(self,expect_active=0)
+
+        sleep(1)
 
 
 

--- a/tests/flow_expire.py
+++ b/tests/flow_expire.py
@@ -83,3 +83,4 @@ class FlowExpire(base_tests.SimpleDataPlane):
         self.assertEqual(match, response.match,
                          'Flow table entry does not match')
         
+        sleep(1)


### PR DESCRIPTION
Reviewer: trivial

For normal flow-mods we can use the barrier message to find out when the
change has made it to the datapath. This isn't the case with timeouts, because
the update isn't associated with any controller connection. When tests are run
in short succession the timed out flow may still exist in the datapath when
the next test starts.