### PR TITLE
OF13 Fix Bucket class watch port and group defaults

### DIFF
--- a/src/python/loxi/of13/common.py
+++ b/src/python/loxi/of13/common.py
@@ -1371,11 +1371,11 @@ class bucket(loxi.OFObject):
         if watch_port != None:
             self.watch_port = watch_port
         else:
-            self.watch_port = 0
+            self.watch_port = ofp.OFPP_ANY
         if watch_group != None:
             self.watch_group = watch_group
         else:
-            self.watch_group = 0
+            self.watch_group = ofp.OFPG_ANY
         if actions != None:
             self.actions = actions
         else:


### PR DESCRIPTION
The Bucket class watch_port and watch_group fields should default to
OFPP_ANY and OFPG_ANY respectively, rather than both defaulting to 0.
Zero is an invalid port number and a valid group number.

See OpenFlow Switch v1.3.4 section 7.3.4.2 for details.

See issue #219 