### PR TITLE
Use bsn_base_error to catch and report gentable errors

### DIFF
--- a/src/python/oftest/testutils.py
+++ b/src/python/oftest/testutils.py
@@ -1775,7 +1775,7 @@ def verify_packets(test, pkt, ofports):
 def verify_no_errors(ctrl):
     error, _ = ctrl.poll(ofp.OFPT_ERROR, 0)
     if error:
-        if error.version >= 3 and isinstance(error, ofp.message.bsn_error):
+        if error.version >= 3 and isinstance(error, ofp.message.bsn_base_error):
             raise AssertionError("unexpected error type=%d msg=%s" %
                                  (error.err_type, error.err_msg))
         else:


### PR DESCRIPTION
Reviewer: @poolakiran 
After this change, we should get a slightly more useful exception, instead of the following:
  File "/usr/lib/python2.7/dist-packages/oftest/testutils.py", line 1783, in verify_no_errors
    (error.err_type, error.code))
  AttributeError: 'bsn_gentable_error' object has no attribute 'code'
